### PR TITLE
Codex-generated pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,48 +1,51 @@
-# ARC-AGI 2 Dataset Exploration Framework
+# PDF 乐谱教材 → 可视化、可审计、可交互、可演奏教学系统
 
-A comprehensive analysis framework for exploring the 1,000 training tasks in the ARC-AGI 2 (Abstraction and Reasoning Corpus - Artificial General Intelligence) dataset. This toolkit provides deep insights into visual reasoning patterns, transformations, and cognitive primitives required for solving these puzzles.
+这个仓库提供一个轻量可扩展的转换管线：将含有 **SHEETMUSIC（乐谱）** 和 **分析图表** 的 PDF 教材，转换为教学系统产物：
 
-## 🎯 Overview
+- `bundle.json`：结构化教学数据（章节、乐句、分析证据、审计日志）
+- `index.html`：可直接打开的互动页面（章节浏览、审计查看、示例播放）
 
-The ARC-AGI 2 dataset contains 1,000 unique visual reasoning tasks that challenge both humans and AI systems. This framework provides:
+## 核心能力
 
-- **Pattern Recognition**: Identifies spatial patterns, symmetries, and transformations
-- **Task Categorization**: Classifies tasks by complexity and cognitive requirements  
-- **Statistical Analysis**: Comprehensive data insights and correlations
-- **Visualization Suite**: Interactive charts, grids, and analysis dashboards
-- **Human Performance Analysis**: Studies solving patterns and success rates
-- **Report Generation**: Detailed analysis summaries and recommendations
+1. **可视化**：输出 HTML 页面展示课程章节、乐谱片段与分析洞见。  
+2. **可审计**：每页分类结果写入 `audit_log`，可追踪自动识别过程。  
+3. **可交互**：前端支持上传 PDF、浏览章节、点击试听示例。  
+4. **可演奏（基础版）**：支持乐句列表及示例声音触发；可扩展为 MIDI/MusicXML 精确回放。  
 
-## 🚀 Quick Start
-
-### Installation
+## 方式一：命令行转换
 
 ```bash
-# Clone the repository
-git clone https://github.com/Phidancer/philo-dancer.git
-cd philo-dancer
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Download ARC-AGI 2 dataset (if not already available)
-python scripts/download_dataset.py
+python -m music_teaching_system.cli /path/to/SchenkerGUIDE.pdf -o teaching_system_output
 ```
 
-### Basic Usage
+## 方式二：Web 上传（推荐）
 
-```python
-from arc_agi_framework import DataLoader, PatternAnalyzer, Visualizer
+启动上传服务：
 
-# Load dataset
-loader = DataLoader()
-tasks = loader.load_training_data()
+```bash
+python -m music_teaching_system.webapp
+```
 
-# Analyze patterns
-analyzer = PatternAnalyzer()
-patterns = analyzer.analyze_all_tasks(tasks)
+然后打开：`http://127.0.0.1:8787`，直接上传 **Pankhurst 的 SchenkerGUIDE PDF**，转换完成后可点开：
 
-# Generate visualizations
-viz = Visualizer()
-viz.create_analysis_dashboard(patterns)
+- 互动页面：`/outputs/<job_id>/index.html`
+- 审计数据：`/outputs/<job_id>/bundle.json`
+
+## 解析说明
+
+- 优先使用 `PyMuPDF`（`fitz`）解析 PDF。
+- 若无 `fitz`，自动尝试 `pypdf`。
+- 若都不可用，回退到文本模式（`\f` 分页），用于最小环境下的流程验证。
+
+## 开发说明
+
+- 主要代码：
+  - `music_teaching_system/pdf_ingest.py`：PDF 解析与页类型分类
+  - `music_teaching_system/pipeline.py`：构建课程数据 + 生成产物
+  - `music_teaching_system/webapp.py`：Web 上传与在线查看
+  - `music_teaching_system/cli.py`：命令行入口
+- 测试：
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py'
 ```

--- a/music_teaching_system/__init__.py
+++ b/music_teaching_system/__init__.py
@@ -1,0 +1,5 @@
+"""PDF-to-Interactive music teaching system toolkit."""
+
+from .pipeline import convert_pdf_to_teaching_system
+
+__all__ = ["convert_pdf_to_teaching_system"]

--- a/music_teaching_system/cli.py
+++ b/music_teaching_system/cli.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .pipeline import convert_pdf_to_teaching_system
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="将包含乐谱与分析图表的 PDF 转化为互动教学系统")
+    parser.add_argument("pdf", help="输入 PDF 路径（或可读取的文本文件）")
+    parser.add_argument("-o", "--output", default="teaching_system_output", help="输出目录")
+    args = parser.parse_args()
+
+    bundle = convert_pdf_to_teaching_system(Path(args.pdf), Path(args.output))
+    print(f"✅ 已生成系统：{args.output}")
+    print(f"- 章节数: {len(bundle.sections)}")
+    print(f"- 审计日志条数: {len(bundle.audit_log)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/music_teaching_system/models.py
+++ b/music_teaching_system/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+
+@dataclass
+class Evidence:
+    source: str
+    page: int
+    excerpt: str
+    confidence: float
+
+
+@dataclass
+class ScoreMeasure:
+    index: int
+    notation: str
+    chord_hint: str | None = None
+    fingering_hint: str | None = None
+
+
+@dataclass
+class AnalysisInsight:
+    insight_type: str
+    title: str
+    description: str
+    evidence: list[Evidence] = field(default_factory=list)
+
+
+@dataclass
+class LessonSection:
+    id: str
+    title: str
+    objective: str
+    measures: list[ScoreMeasure] = field(default_factory=list)
+    insights: list[AnalysisInsight] = field(default_factory=list)
+
+
+@dataclass
+class TeachingSystemBundle:
+    title: str
+    source_pdf: str
+    sections: list[LessonSection]
+    audit_log: list[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/music_teaching_system/pdf_ingest.py
+++ b/music_teaching_system/pdf_ingest.py
@@ -32,9 +32,20 @@ def _parse_with_pypdf(path: Path) -> ParsedPDF:
     from pypdf import PdfReader  # type: ignore
 
     reader = PdfReader(str(path))
-    pages = []
-    for idx, page in enumerate(reader.pages, start=1):
-        pages.append(ExtractedPage(page=idx, text=page.extract_text() or ""))
+    pages = [ExtractedPage(page=idx, text=page.extract_text() or "") for idx, page in enumerate(reader.pages, start=1)]
+    return ParsedPDF(title=path.stem, pages=pages)
+
+
+def _parse_text_fallback(path: Path) -> ParsedPDF:
+    raw = path.read_bytes().decode("utf-8", errors="ignore")
+    if path.suffix.lower() == ".pdf":
+        printable_ratio = (sum(ch.isprintable() for ch in raw) / max(len(raw), 1))
+        if printable_ratio < 0.8:
+            # Likely binary PDF bytes without successful text extraction.
+            return ParsedPDF(title=path.stem, pages=[ExtractedPage(page=1, text="")])
+
+    segments = [s.strip() for s in raw.split("\f") if s.strip()] or [raw]
+    pages = [ExtractedPage(page=i + 1, text=text) for i, text in enumerate(segments)]
     return ParsedPDF(title=path.stem, pages=pages)
 
 
@@ -48,17 +59,13 @@ def parse_pdf(pdf_path: str | Path) -> ParsedPDF:
     """
 
     path = Path(pdf_path)
-
     for parser in (_parse_with_pymupdf, _parse_with_pypdf):
         try:
             return parser(path)
         except Exception:
             continue
 
-    raw = path.read_text(encoding="utf-8", errors="ignore")
-    segments = [s.strip() for s in raw.split("\f") if s.strip()] or [raw]
-    pages = [ExtractedPage(page=i + 1, text=text) for i, text in enumerate(segments)]
-    return ParsedPDF(title=path.stem, pages=pages)
+    return _parse_text_fallback(path)
 
 
 def classify_page(text: str) -> str:

--- a/music_teaching_system/pdf_ingest.py
+++ b/music_teaching_system/pdf_ingest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ExtractedPage:
+    page: int
+    text: str
+
+
+@dataclass
+class ParsedPDF:
+    title: str
+    pages: list[ExtractedPage]
+
+
+KEYWORDS_SCORE = {"sheet", "staff", "measure", "谱", "五线谱", "音符"}
+KEYWORDS_ANALYSIS = {"analysis", "chart", "diagram", "form", "harmony", "分析", "图表", "schenker"}
+
+
+def _parse_with_pymupdf(path: Path) -> ParsedPDF:
+    import fitz  # type: ignore
+
+    doc = fitz.open(path)
+    pages = [ExtractedPage(page=i + 1, text=doc[i].get_text("text")) for i in range(len(doc))]
+    return ParsedPDF(title=path.stem, pages=pages)
+
+
+def _parse_with_pypdf(path: Path) -> ParsedPDF:
+    from pypdf import PdfReader  # type: ignore
+
+    reader = PdfReader(str(path))
+    pages = []
+    for idx, page in enumerate(reader.pages, start=1):
+        pages.append(ExtractedPage(page=idx, text=page.extract_text() or ""))
+    return ParsedPDF(title=path.stem, pages=pages)
+
+
+def parse_pdf(pdf_path: str | Path) -> ParsedPDF:
+    """Extract text from PDF.
+
+    Priority:
+    1) PyMuPDF (fitz)
+    2) pypdf
+    3) UTF-8 text fallback split by form-feed
+    """
+
+    path = Path(pdf_path)
+
+    for parser in (_parse_with_pymupdf, _parse_with_pypdf):
+        try:
+            return parser(path)
+        except Exception:
+            continue
+
+    raw = path.read_text(encoding="utf-8", errors="ignore")
+    segments = [s.strip() for s in raw.split("\f") if s.strip()] or [raw]
+    pages = [ExtractedPage(page=i + 1, text=text) for i, text in enumerate(segments)]
+    return ParsedPDF(title=path.stem, pages=pages)
+
+
+def classify_page(text: str) -> str:
+    lower = text.lower()
+    score_hits = sum(1 for k in KEYWORDS_SCORE if k in lower)
+    analysis_hits = sum(1 for k in KEYWORDS_ANALYSIS if k in lower)
+    if score_hits and analysis_hits:
+        return "hybrid"
+    if score_hits:
+        return "sheetmusic"
+    if analysis_hits:
+        return "analysis"
+    return "context"

--- a/music_teaching_system/pipeline.py
+++ b/music_teaching_system/pipeline.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .models import AnalysisInsight, Evidence, LessonSection, ScoreMeasure, TeachingSystemBundle
+from .pdf_ingest import classify_page, parse_pdf
+
+
+def _build_sections(pdf_text_pages: list[tuple[int, str]]) -> tuple[list[LessonSection], list[str]]:
+    sections: list[LessonSection] = []
+    audit: list[str] = []
+
+    for page_number, text in pdf_text_pages:
+        page_type = classify_page(text)
+        audit.append(f"page={page_number} classified_as={page_type}")
+
+        if page_type in {"sheetmusic", "hybrid"}:
+            measures = []
+            for idx, line in enumerate(text.splitlines(), start=1):
+                if "|" in line or "measure" in line.lower() or "小节" in line:
+                    measures.append(ScoreMeasure(index=idx, notation=line.strip()[:120]))
+
+            if not measures:
+                measures = [ScoreMeasure(index=1, notation="(auto-detected phrase)")]
+
+            sections.append(
+                LessonSection(
+                    id=f"score-{page_number}",
+                    title=f"乐谱页 {page_number}",
+                    objective="识别旋律结构并支持交互演奏",
+                    measures=measures,
+                )
+            )
+
+        if page_type in {"analysis", "hybrid"}:
+            insight = AnalysisInsight(
+                insight_type="theory",
+                title=f"分析图表页 {page_number}",
+                description="提取结构/和声/动机信息并关联到对应乐谱段落",
+                evidence=[
+                    Evidence(
+                        source="pdf",
+                        page=page_number,
+                        excerpt=text.strip().replace("\n", " ")[:200],
+                        confidence=0.68,
+                    )
+                ],
+            )
+
+            sections.append(
+                LessonSection(
+                    id=f"analysis-{page_number}",
+                    title=f"分析页 {page_number}",
+                    objective="建立可审计的分析链路",
+                    insights=[insight],
+                )
+            )
+
+    if not sections:
+        sections.append(
+            LessonSection(
+                id="fallback-1",
+                title="自动导入内容",
+                objective="未识别到乐谱/图表关键词，已生成基础课程壳。",
+                measures=[ScoreMeasure(index=1, notation="请补充人工校对后的乐谱片段")],
+            )
+        )
+        audit.append("fallback section generated")
+
+    return sections, audit
+
+
+def _build_html(bundle: TeachingSystemBundle) -> str:
+    payload = json.dumps(bundle.to_dict(), ensure_ascii=False)
+    return f"""<!doctype html>
+<html lang='zh-CN'>
+<head>
+  <meta charset='UTF-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+  <title>{bundle.title} - 互动教学系统</title>
+  <style>
+    body {{ font-family: sans-serif; margin: 0; background:#0f172a; color:#e2e8f0; }}
+    .wrap {{ max-width: 980px; margin: 0 auto; padding: 24px; }}
+    .card {{ background:#1e293b; border-radius: 12px; padding: 16px; margin-bottom: 16px; }}
+    button {{ background:#22c55e; border:0; padding:8px 12px; border-radius:8px; cursor:pointer; }}
+    pre {{ white-space: pre-wrap; }}
+  </style>
+</head>
+<body>
+<div class='wrap'>
+  <h1>🎼 {bundle.title}：可视化/可审计/可交互教学系统</h1>
+  <p>支持审计日志追踪、章节浏览、乐句播放（示例音频）与分析证据查看。</p>
+  <div id='app'></div>
+</div>
+<script>
+const bundle = {payload};
+const app = document.getElementById('app');
+
+function beep() {{
+  const ctx = new (window.AudioContext || window.webkitAudioContext)();
+  const osc = ctx.createOscillator();
+  osc.type = 'sine';
+  osc.frequency.value = 440;
+  osc.connect(ctx.destination);
+  osc.start();
+  setTimeout(() => osc.stop(), 180);
+}}
+
+bundle.sections.forEach(section => {{
+  const div = document.createElement('div');
+  div.className = 'card';
+  const measures = (section.measures || []).map(m => `<li>#${{m.index}} ${{m.notation}}</li>`).join('');
+  const insights = (section.insights || []).map(i => `<li><b>${{i.title}}</b>：${{i.description}}</li>`).join('');
+  div.innerHTML = `
+    <h3>${{section.title}}</h3>
+    <p>目标：${{section.objective}}</p>
+    ${{measures ? `<h4>可演奏片段</h4><ul>${{measures}}</ul>` : ''}}
+    ${{insights ? `<h4>分析洞见</h4><ul>${{insights}}</ul>` : ''}}
+    <button>▶ 试听示例</button>
+  `;
+  div.querySelector('button')?.addEventListener('click', beep);
+  app.appendChild(div);
+}});
+
+const audit = document.createElement('div');
+audit.className = 'card';
+audit.innerHTML = `<h3>审计日志</h3><pre>${{bundle.audit_log.join('\n')}}</pre>`;
+app.appendChild(audit);
+</script>
+</body>
+</html>
+"""
+
+
+def convert_pdf_to_teaching_system(pdf_path: str | Path, output_dir: str | Path) -> TeachingSystemBundle:
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+
+    parsed = parse_pdf(pdf_path)
+    pages = [(p.page, p.text) for p in parsed.pages]
+    sections, audit = _build_sections(pages)
+
+    bundle = TeachingSystemBundle(
+        title=parsed.title,
+        source_pdf=str(pdf_path),
+        sections=sections,
+        audit_log=audit,
+        metadata={"page_count": len(parsed.pages), "version": "0.1.0"},
+    )
+
+    json_path = output / "bundle.json"
+    json_path.write_text(json.dumps(bundle.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+
+    html_path = output / "index.html"
+    html_path.write_text(_build_html(bundle), encoding="utf-8")
+
+    return bundle

--- a/music_teaching_system/pipeline.py
+++ b/music_teaching_system/pipeline.py
@@ -81,7 +81,7 @@ def _build_sections(pdf_text_pages: list[tuple[int, str]]) -> tuple[list[LessonS
 
 
 def _build_html(bundle: TeachingSystemBundle) -> str:
-    payload = json.dumps(bundle.to_dict(), ensure_ascii=False)
+    payload = json.dumps(bundle.to_dict(), ensure_ascii=False).replace("</", "<\\/")
     return f"""<!doctype html>
 <html lang='zh-CN'>
 <head>
@@ -94,6 +94,7 @@ def _build_html(bundle: TeachingSystemBundle) -> str:
     .card {{ background:#1e293b; border-radius: 12px; padding: 16px; margin-bottom: 16px; }}
     button {{ background:#22c55e; border:0; padding:8px 12px; border-radius:8px; cursor:pointer; }}
     pre {{ white-space: pre-wrap; }}
+    .error {{ border: 1px solid #ef4444; color: #fecaca; }}
   </style>
 </head>
 <body>
@@ -102,9 +103,25 @@ def _build_html(bundle: TeachingSystemBundle) -> str:
   <p>支持审计日志追踪、章节浏览、乐句播放（示例音频）与分析证据查看。</p>
   <div id='app'></div>
 </div>
+<script id='bundle-data' type='application/json'>{payload}</script>
 <script>
-const bundle = {payload};
 const app = document.getElementById('app');
+
+function showError(message) {{
+  const err = document.createElement('div');
+  err.className = 'card error';
+  err.textContent = message;
+  app.appendChild(err);
+}}
+
+function escapeHtml(value) {{
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}}
 
 function beep() {{
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -116,26 +133,70 @@ function beep() {{
   setTimeout(() => osc.stop(), 180);
 }}
 
-bundle.sections.forEach(section => {{
-  const div = document.createElement('div');
-  div.className = 'card';
-  const measures = (section.measures || []).map(m => `<li>#${{m.index}} ${{m.notation}}</li>`).join('');
-  const insights = (section.insights || []).map(i => `<li><b>${{i.title}}</b>：${{i.description}}</li>`).join('');
-  div.innerHTML = `
-    <h3>${{section.title}}</h3>
-    <p>目标：${{section.objective}}</p>
-    ${{measures ? `<h4>可演奏片段</h4><ul>${{measures}}</ul>` : ''}}
-    ${{insights ? `<h4>分析洞见</h4><ul>${{insights}}</ul>` : ''}}
-    <button>▶ 试听示例</button>
-  `;
-  div.querySelector('button')?.addEventListener('click', beep);
-  app.appendChild(div);
-}});
+try {{
+  const raw = document.getElementById('bundle-data')?.textContent || '{{}}';
+  const bundle = JSON.parse(raw);
 
-const audit = document.createElement('div');
-audit.className = 'card';
-audit.innerHTML = `<h3>审计日志</h3><pre>${{bundle.audit_log.join('\n')}}</pre>`;
-app.appendChild(audit);
+  (bundle.sections || []).forEach((section) => {{
+    const div = document.createElement('div');
+    div.className = 'card';
+
+    const title = document.createElement('h3');
+    title.textContent = section.title || '未命名章节';
+    div.appendChild(title);
+
+    const objective = document.createElement('p');
+    objective.textContent = `目标：${{section.objective || ''}}`;
+    div.appendChild(objective);
+
+    if ((section.measures || []).length) {{
+      const h = document.createElement('h4');
+      h.textContent = '可演奏片段';
+      div.appendChild(h);
+
+      const ul = document.createElement('ul');
+      (section.measures || []).forEach((m) => {{
+        const li = document.createElement('li');
+        li.innerHTML = `#${{escapeHtml(m.index)}} ${{escapeHtml(m.notation || '')}}`;
+        ul.appendChild(li);
+      }});
+      div.appendChild(ul);
+    }}
+
+    if ((section.insights || []).length) {{
+      const h = document.createElement('h4');
+      h.textContent = '分析洞见';
+      div.appendChild(h);
+
+      const ul = document.createElement('ul');
+      (section.insights || []).forEach((i) => {{
+        const li = document.createElement('li');
+        li.innerHTML = `<b>${{escapeHtml(i.title || '')}}</b>：${{escapeHtml(i.description || '')}}`;
+        ul.appendChild(li);
+      }});
+      div.appendChild(ul);
+    }}
+
+    const btn = document.createElement('button');
+    btn.textContent = '▶ 试听示例';
+    btn.addEventListener('click', beep);
+    div.appendChild(btn);
+
+    app.appendChild(div);
+  }});
+
+  const audit = document.createElement('div');
+  audit.className = 'card';
+  const h = document.createElement('h3');
+  h.textContent = '审计日志';
+  audit.appendChild(h);
+  const pre = document.createElement('pre');
+  pre.textContent = (bundle.audit_log || []).join('\n');
+  audit.appendChild(pre);
+  app.appendChild(audit);
+}} catch (error) {{
+  showError(`页面渲染失败：${{error}}`);
+}}
 </script>
 </body>
 </html>

--- a/music_teaching_system/pipeline.py
+++ b/music_teaching_system/pipeline.py
@@ -11,9 +11,13 @@ def _build_sections(pdf_text_pages: list[tuple[int, str]]) -> tuple[list[LessonS
     sections: list[LessonSection] = []
     audit: list[str] = []
 
+    non_empty_pages = 0
     for page_number, text in pdf_text_pages:
+        if text.strip():
+            non_empty_pages += 1
+
         page_type = classify_page(text)
-        audit.append(f"page={page_number} classified_as={page_type}")
+        audit.append(f"page={page_number} classified_as={page_type} chars={len(text.strip())}")
 
         if page_type in {"sheetmusic", "hybrid"}:
             measures = []
@@ -58,11 +62,16 @@ def _build_sections(pdf_text_pages: list[tuple[int, str]]) -> tuple[list[LessonS
             )
 
     if not sections:
+        objective = "未识别到乐谱/图表关键词，已生成基础课程壳。"
+        if non_empty_pages == 0:
+            objective = "未提取到可读文本（常见于扫描版 PDF）。请先进行 OCR 再上传，或安装可用 PDF 解析依赖。"
+            audit.append("warning: no readable text extracted from source")
+
         sections.append(
             LessonSection(
                 id="fallback-1",
                 title="自动导入内容",
-                objective="未识别到乐谱/图表关键词，已生成基础课程壳。",
+                objective=objective,
                 measures=[ScoreMeasure(index=1, notation="请补充人工校对后的乐谱片段")],
             )
         )

--- a/music_teaching_system/webapp.py
+++ b/music_teaching_system/webapp.py
@@ -92,16 +92,18 @@ class UploadHandler(BaseHTTPRequestHandler):
 
         safe_name = Path(file_item.filename).name
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        job_id = f"{timestamp}-{safe_name.replace(' ', '_')}"
+        safe_stem = Path(safe_name).stem.replace(' ', '_')
+        safe_suffix = Path(safe_name).suffix.lower()
+        job_id = f"{timestamp}-{safe_stem}"
 
         UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
         OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
 
-        upload_path = UPLOAD_DIR / job_id
+        upload_path = UPLOAD_DIR / f"{job_id}{safe_suffix}"
         with upload_path.open("wb") as f:
             shutil.copyfileobj(file_item.file, f)
 
-        output_dir = OUTPUT_ROOT / job_id
+        output_dir = OUTPUT_ROOT / Path(upload_path).stem
         bundle = convert_pdf_to_teaching_system(upload_path, output_dir)
 
         summary = {
@@ -117,8 +119,8 @@ class UploadHandler(BaseHTTPRequestHandler):
 <div class='card'>
   <p><b>教材：</b>{html.escape(bundle.title)}</p>
   <p><b>章节数：</b>{len(bundle.sections)}，<b>审计日志：</b>{len(bundle.audit_log)}</p>
-  <p><a href='/outputs/{job_id}/index.html' target='_blank'>打开互动教学页面</a></p>
-  <p><a href='/outputs/{job_id}/bundle.json' target='_blank'>查看 bundle.json</a></p>
+  <p><a href='/outputs/{Path(upload_path).stem}/index.html' target='_blank'>打开互动教学页面</a></p>
+  <p><a href='/outputs/{Path(upload_path).stem}/bundle.json' target='_blank'>查看 bundle.json</a></p>
 </div>
 <div class='card'>
   <h3>转换摘要</h3>

--- a/music_teaching_system/webapp.py
+++ b/music_teaching_system/webapp.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import html
+import json
+import shutil
+from datetime import datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from .pipeline import convert_pdf_to_teaching_system
+
+APP_TITLE = "Schenker 教材转换器"
+UPLOAD_DIR = Path("web_uploads")
+OUTPUT_ROOT = Path("web_outputs")
+
+
+def _html_page(body: str) -> bytes:
+    page = f"""<!doctype html>
+<html lang='zh-CN'>
+<head>
+  <meta charset='UTF-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+  <title>{APP_TITLE}</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; background: #0f172a; color: #e2e8f0; margin: 0; }}
+    .wrap {{ max-width: 980px; margin: 0 auto; padding: 24px; }}
+    .card {{ background: #1e293b; border-radius: 12px; padding: 16px; margin-bottom: 16px; }}
+    .row {{ display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }}
+    input, button {{ font-size: 16px; }}
+    input[type='file'] {{ background:#0b1220; border:1px solid #334155; color:#e2e8f0; padding:8px; border-radius:8px; }}
+    button {{ background:#22c55e; border:0; padding:8px 14px; border-radius:8px; cursor:pointer; color:#052e16; font-weight:600; }}
+    a {{ color: #93c5fd; }}
+    code {{ background:#334155; padding:2px 6px; border-radius:6px; }}
+    .muted {{ color:#94a3b8; }}
+  </style>
+</head>
+<body>
+<div class='wrap'>{body}</div>
+</body>
+</html>"""
+    return page.encode("utf-8")
+
+
+class UploadHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path.startswith("/outputs/"):
+            self._serve_output_file()
+            return
+
+        body = """
+<h1>🎼 Schenker 教材转换器</h1>
+<div class='card'>
+  <p>上传 Pankhurst 的 <b>SchenkerGUIDE PDF</b>（或其他包含乐谱与分析图表的教材），自动生成：</p>
+  <ul>
+    <li><code>bundle.json</code>：可审计教学结构化数据</li>
+    <li><code>index.html</code>：可视化、可交互、可演奏（示例）页面</li>
+  </ul>
+  <form action='/upload' method='post' enctype='multipart/form-data'>
+    <div class='row'>
+      <input id='pdf-input' type='file' name='pdf' accept='.pdf,.txt' required />
+      <button id='submit-btn' type='submit'>开始转换</button>
+    </div>
+  </form>
+  <p class='muted'>如果你之前遇到“无法点击”，请直接点击上方文件选择框并选择 PDF 后点击“开始转换”。</p>
+</div>
+<p class='muted'>提示：若环境已安装 PyMuPDF 或 pypdf，将优先用 PDF 解析；否则回退文本解析。</p>
+"""
+        self._send_html(body)
+
+    def do_POST(self) -> None:
+        if self.path != "/upload":
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown endpoint")
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+        if "multipart/form-data" not in content_type:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Expected multipart/form-data")
+            return
+
+        import cgi
+
+        fs = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={"REQUEST_METHOD": "POST", "CONTENT_TYPE": content_type},
+        )
+        file_item = fs["pdf"] if "pdf" in fs else None
+        if file_item is None or not getattr(file_item, "filename", ""):
+            self.send_error(HTTPStatus.BAD_REQUEST, "No file uploaded")
+            return
+
+        safe_name = Path(file_item.filename).name
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        job_id = f"{timestamp}-{safe_name.replace(' ', '_')}"
+
+        UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+        OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+
+        upload_path = UPLOAD_DIR / job_id
+        with upload_path.open("wb") as f:
+            shutil.copyfileobj(file_item.file, f)
+
+        output_dir = OUTPUT_ROOT / job_id
+        bundle = convert_pdf_to_teaching_system(upload_path, output_dir)
+
+        summary = {
+            "title": bundle.title,
+            "source_pdf": bundle.source_pdf,
+            "section_count": len(bundle.sections),
+            "audit_count": len(bundle.audit_log),
+            "metadata": bundle.metadata,
+        }
+
+        body = f"""
+<h1>✅ 转换完成</h1>
+<div class='card'>
+  <p><b>教材：</b>{html.escape(bundle.title)}</p>
+  <p><b>章节数：</b>{len(bundle.sections)}，<b>审计日志：</b>{len(bundle.audit_log)}</p>
+  <p><a href='/outputs/{job_id}/index.html' target='_blank'>打开互动教学页面</a></p>
+  <p><a href='/outputs/{job_id}/bundle.json' target='_blank'>查看 bundle.json</a></p>
+</div>
+<div class='card'>
+  <h3>转换摘要</h3>
+  <pre>{html.escape(json.dumps(summary, ensure_ascii=False, indent=2))}</pre>
+</div>
+<p><a href='/'>← 继续上传</a></p>
+"""
+        self._send_html(body)
+
+    def _serve_output_file(self) -> None:
+        rel = self.path[len("/outputs/") :]
+        target = (OUTPUT_ROOT / rel).resolve()
+        if not str(target).startswith(str(OUTPUT_ROOT.resolve())):
+            self.send_error(HTTPStatus.FORBIDDEN, "Invalid path")
+            return
+        if not target.exists() or not target.is_file():
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return
+
+        if target.suffix == ".html":
+            ctype = "text/html; charset=utf-8"
+        elif target.suffix == ".json":
+            ctype = "application/json; charset=utf-8"
+        else:
+            ctype = "application/octet-stream"
+
+        data = target.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_html(self, body: str) -> None:
+        data = _html_page(body)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def run_server(host: str = "0.0.0.0", port: int = 8787) -> None:
+    server = ThreadingHTTPServer((host, port), UploadHandler)
+    print(f"🚀 Web 上传服务已启动: http://{host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -45,6 +45,17 @@ class PipelineTests(unittest.TestCase):
             self.assertTrue(any("no readable text" in x for x in bundle.audit_log))
             self.assertIn("OCR", bundle.sections[0].objective)
 
+
+    def test_html_escapes_script_end_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "lesson.txt"
+            out = Path(tmp) / "out"
+            source.write_text("analysis </script> chart", encoding="utf-8")
+            convert_pdf_to_teaching_system(source, out)
+            html = (out / "index.html").read_text(encoding="utf-8")
+            self.assertIn("<script id='bundle-data' type='application/json'>", html)
+            self.assertIn(r"<\/script>", html)
+
     def test_web_html_wrapper(self):
         page = _html_page("<h1>ok</h1>").decode("utf-8")
         self.assertIn("Schenker 教材转换器", page)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,6 +35,16 @@ class PipelineTests(unittest.TestCase):
         text = "SHEET staff measure 1 with harmony analysis chart"
         self.assertEqual(classify_page(text), "hybrid")
 
+
+    def test_binary_pdf_fallback_has_ocr_hint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "scan.pdf"
+            out = Path(tmp) / "out"
+            source.write_bytes(b"%PDF-1.7\x00\x01\x02\x03\xff\xfe")
+            bundle = convert_pdf_to_teaching_system(source, out)
+            self.assertTrue(any("no readable text" in x for x in bundle.audit_log))
+            self.assertIn("OCR", bundle.sections[0].objective)
+
     def test_web_html_wrapper(self):
         page = _html_page("<h1>ok</h1>").decode("utf-8")
         self.assertIn("Schenker 教材转换器", page)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from music_teaching_system.pdf_ingest import classify_page, parse_pdf
+from music_teaching_system.pipeline import convert_pdf_to_teaching_system
+from music_teaching_system.webapp import _html_page
+
+
+class PipelineTests(unittest.TestCase):
+    def test_convert_text_backed_material(self):
+        content = "SHEET staff measure 1 | C D E F\fHarmony analysis chart form"
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "lesson.txt"
+            out = Path(tmp) / "out"
+            source.write_text(content, encoding="utf-8")
+
+            bundle = convert_pdf_to_teaching_system(source, out)
+
+            self.assertGreaterEqual(len(bundle.sections), 2)
+            self.assertTrue((out / "bundle.json").exists())
+            self.assertTrue((out / "index.html").exists())
+            self.assertTrue(any("classified_as=sheetmusic" in x for x in bundle.audit_log))
+            self.assertTrue(any("classified_as=analysis" in x for x in bundle.audit_log))
+
+    def test_parse_pdf_text_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "mock.pdf"
+            source.write_text("Page 1\fPage 2", encoding="utf-8")
+            parsed = parse_pdf(source)
+            self.assertEqual(parsed.title, "mock")
+            self.assertEqual(len(parsed.pages), 2)
+
+    def test_classify_hybrid_page(self):
+        text = "SHEET staff measure 1 with harmony analysis chart"
+        self.assertEqual(classify_page(text), "hybrid")
+
+    def test_web_html_wrapper(self):
+        page = _html_page("<h1>ok</h1>").decode("utf-8")
+        self.assertIn("Schenker 教材转换器", page)
+        self.assertIn("<h1>ok</h1>", page)
+        self.assertIn("<title>Schenker 教材转换器</title>", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e565be288323940c48053e00729e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New end-to-end file ingestion and HTML generation plus an upload server increases risk of parsing edge cases and serving output files, though scope is contained and covered by basic tests.
> 
> **Overview**
> Adds a new `music_teaching_system` package that converts a PDF (or text fallback) into a teaching bundle (`bundle.json`) plus a self-contained interactive `index.html`, including per-page classification and an `audit_log` for traceability.
> 
> Introduces a lightweight PDF ingestion layer with `PyMuPDF`/`pypdf` fallback, heuristics to classify pages as `sheetmusic`/`analysis`/`hybrid`, and generates basic sections/measures/insights (with an OCR hint fallback when no readable text is extracted). Also adds a simple built-in web uploader/viewer server, a CLI entrypoint, unit tests covering fallbacks and HTML escaping, and updates `.gitignore`/`README` to document the new tool.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5b86615e6a9c5b0dc4eb42efc0798500e7be286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->